### PR TITLE
feat: default startup screen setting + calculator in unit converter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,6 @@
 .externalNativeBuild
 .cxx
 *.hprof
-backup/
+backup/*.txt
+logcat*.txt
+live_logcat.txt

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "com.vedtechnologies.toolbox"
         minSdk = 26
         targetSdk = 36
-        versionCode = 4
-        versionName = "1.3.0"
+        versionCode = 5
+        versionName = "1.3.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/toolbox/MainActivity.kt
+++ b/app/src/main/java/com/toolbox/MainActivity.kt
@@ -22,7 +22,17 @@ class MainActivity : ComponentActivity() {
         setContent {
             val themeMode by preferencesRepository.themeMode
                 .collectAsState(initial = ThemeMode.System)
-            ToolboxApp(themeMode = themeMode, launchToolId = launchToolId)
+            val defaultScreenId by preferencesRepository.defaultScreenId
+                .collectAsState(initial = null)
+
+            // Wait until the preference is loaded to avoid flashing the wrong screen
+            val resolvedDefault = defaultScreenId ?: return@setContent
+
+            ToolboxApp(
+                themeMode = themeMode,
+                launchToolId = launchToolId,
+                defaultScreenId = resolvedDefault,
+            )
         }
     }
 }

--- a/app/src/main/java/com/toolbox/ToolboxApp.kt
+++ b/app/src/main/java/com/toolbox/ToolboxApp.kt
@@ -170,11 +170,23 @@ import com.toolbox.settings.SettingsScreen
 
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
-fun ToolboxApp(themeMode: ThemeMode, launchToolId: String? = null) {
+fun ToolboxApp(themeMode: ThemeMode, launchToolId: String? = null, defaultScreenId: String = "dashboard") {
     ToolboxTheme(themeMode = themeMode) {
         Surface(modifier = Modifier.fillMaxSize()) {
             val navController = rememberNavController()
 
+            // Determine start destination and initial Favorites tab state
+            val isDefaultTool = defaultScreenId != "dashboard" && defaultScreenId != "favorites"
+            val startDest: Any = if (isDefaultTool) {
+                toolDestination(defaultScreenId) ?: Dashboard
+            } else {
+                Dashboard
+            }
+            val initialTab = when {
+                isDefaultTool -> 0 // not used on Dashboard when starting on a tool
+                defaultScreenId == "favorites" -> 1
+                else -> 0
+            }
             // Handle deep-link from Quick Settings tile
             androidx.compose.runtime.LaunchedEffect(launchToolId) {
                 if (launchToolId != null) {
@@ -188,14 +200,14 @@ fun ToolboxApp(themeMode: ThemeMode, launchToolId: String? = null) {
             SharedTransitionLayout {
                 NavHost(
                     navController = navController,
-                    startDestination = Dashboard,
+                    startDestination = startDest,
                     enterTransition = { fadeIn(tween(220, easing = EaseOutCubic)) + slideInHorizontally(tween(220, easing = EaseOutCubic)) { it / 4 } },
                     exitTransition = { fadeOut(tween(220, easing = EaseOutCubic)) },
                     popEnterTransition = { fadeIn(tween(220, easing = EaseOutCubic)) },
                     popExitTransition = { fadeOut(tween(220, easing = EaseOutCubic)) + slideOutHorizontally(tween(220, easing = EaseOutCubic)) { it / 4 } },
                 ) {
                     composable<Dashboard> {
-                        var selectedTab by rememberSaveable { mutableIntStateOf(0) }
+                        var selectedTab by rememberSaveable { mutableIntStateOf(initialTab) }
 
                         Scaffold(
                             topBar = {
@@ -272,66 +284,66 @@ fun ToolboxApp(themeMode: ThemeMode, launchToolId: String? = null) {
                         }
                     }
 
-                    // Tool screens
-                    composable<Level> { ToolScreen("Bubble Level", "level", navController, this@SharedTransitionLayout, this@composable) { LevelScreen() } }
-                    composable<Compass> { ToolScreen("Compass", "compass", navController, this@SharedTransitionLayout, this@composable) { CompassScreen() } }
-                    composable<Protractor> { ToolScreen("Protractor", "protractor", navController, this@SharedTransitionLayout, this@composable) { ProtractorScreen() } }
-                    composable<SoundMeter> { ToolScreen("Sound Meter", "sound_meter", navController, this@SharedTransitionLayout, this@composable) { SoundMeterScreen() } }
-                    composable<Ruler> { ToolScreen("Ruler", "ruler", navController, this@SharedTransitionLayout, this@composable) { RulerScreen() } }
-                    composable<UnitConverter> { ToolScreen("Unit Converter", "unit_converter", navController, this@SharedTransitionLayout, this@composable) { UnitConverterScreen() } }
-                    composable<PercentageCalculator> { ToolScreen("Percentage", "percentage", navController, this@SharedTransitionLayout, this@composable) { PercentageScreen() } }
-                    composable<TipCalculator> { ToolScreen("Tip Calculator", "tip_calculator", navController, this@SharedTransitionLayout, this@composable) { TipCalculatorScreen() } }
-                    composable<NumberBase> { ToolScreen("Number Base", "number_base", navController, this@SharedTransitionLayout, this@composable) { NumberBaseScreen() } }
-                    composable<Flashlight> { ToolScreen("Flashlight", "flashlight", navController, this@SharedTransitionLayout, this@composable) { FlashlightScreen() } }
-                    composable<QrScanner> { ToolScreen("QR & Barcode", "qr_scanner", navController, this@SharedTransitionLayout, this@composable) { QrScannerScreen() } }
-                    composable<Counter> { ToolScreen("Counter", "counter", navController, this@SharedTransitionLayout, this@composable) { CounterScreen() } }
-                    composable<StopwatchTimer> { ToolScreen("Stopwatch & Timer", "stopwatch_timer", navController, this@SharedTransitionLayout, this@composable) { StopwatchTimerScreen() } }
-                    composable<RandomGenerator> { ToolScreen("Random Generator", "random_generator", navController, this@SharedTransitionLayout, this@composable) { RandomScreen() } }
-                    composable<ColorPicker> { ToolScreen("Color Picker", "color_picker", navController, this@SharedTransitionLayout, this@composable) { ColorPickerScreen() } }
-                    composable<Magnifier> { ToolScreen("Magnifier", "magnifier", navController, this@SharedTransitionLayout, this@composable) { MagnifierScreen() } }
-                    composable<Mirror> { ToolScreen("Mirror", "mirror", navController, this@SharedTransitionLayout, this@composable) { MirrorScreen() } }
-                    composable<Vibrometer> { ToolScreen("Vibrometer", "vibrometer", navController, this@SharedTransitionLayout, this@composable) { VibrometerScreen() } }
-                    composable<LightMeter> { ToolScreen("Light Meter", "light_meter", navController, this@SharedTransitionLayout, this@composable) { LightMeterScreen() } }
-                    composable<MetalDetector> { ToolScreen("Metal Detector", "metal_detector", navController, this@SharedTransitionLayout, this@composable) { MetalDetectorScreen() } }
-                    composable<Barometer> { ToolScreen("Barometer", "barometer", navController, this@SharedTransitionLayout, this@composable) { BarometerScreen() } }
-                    composable<Humidity> { ToolScreen("Humidity", "humidity", navController, this@SharedTransitionLayout, this@composable) { HumidityScreen() } }
-                    composable<Pedometer> { ToolScreen("Pedometer", "pedometer", navController, this@SharedTransitionLayout, this@composable) { PedometerScreen() } }
-                    composable<Gyroscope> { ToolScreen("Gyroscope", "gyroscope", navController, this@SharedTransitionLayout, this@composable) { GyroscopeScreen() } }
-                    composable<HeartRate> { ToolScreen("Heart Rate", "heart_rate", navController, this@SharedTransitionLayout, this@composable) { HeartRateScreen() } }
-                    composable<SpectrumAnalyzer> { ToolScreen("Spectrum Analyzer", "spectrum_analyzer", navController, this@SharedTransitionLayout, this@composable) { SpectrumScreen() } }
-                    composable<Speedometer> { ToolScreen("Speedometer", "speedometer", navController, this@SharedTransitionLayout, this@composable) { SpeedometerScreen() } }
-                    composable<Altitude> { ToolScreen("Altitude", "altitude", navController, this@SharedTransitionLayout, this@composable) { AltitudeScreen() } }
-                    composable<BreathingExercise> { ToolScreen("Breathing Exercise", "breathing_exercise", navController, this@SharedTransitionLayout, this@composable) { BreathingExerciseScreen() } }
-                    composable<ScientificCalculator> { ToolScreen("Calculator", "scientific_calculator", navController, this@SharedTransitionLayout, this@composable) { CalculatorScreen() } }
-                    composable<MorseCode> { ToolScreen("Morse Code", "morse_code", navController, this@SharedTransitionLayout, this@composable) { MorseCodeScreen() } }
-                    composable<DateCalculator> { ToolScreen("Date/Age Calculator", "date_calculator", navController, this@SharedTransitionLayout, this@composable) { DateCalculatorScreen() } }
-                    composable<BmiCalculator> { ToolScreen("BMI Calculator", "bmi_calculator", navController, this@SharedTransitionLayout, this@composable) { BmiCalculatorScreen() } }
-                    composable<AspectRatio> { ToolScreen("Aspect Ratio", "aspect_ratio", navController, this@SharedTransitionLayout, this@composable) { AspectRatioScreen() } }
-                    composable<PasswordGenerator> { ToolScreen("Password Generator", "password_generator", navController, this@SharedTransitionLayout, this@composable) { PasswordGeneratorScreen() } }
-                    composable<WhiteNoise> { ToolScreen("Ambient Sounds", "white_noise", navController, this@SharedTransitionLayout, this@composable) { WhiteNoiseScreen() } }
-                    composable<Metronome> { ToolScreen("Metronome", "metronome", navController, this@SharedTransitionLayout, this@composable) { MetronomeScreen() } }
-                    composable<PitchTuner> { ToolScreen("Pitch Tuner", "pitch_tuner", navController, this@SharedTransitionLayout, this@composable) { PitchTunerScreen() } }
-                    composable<ScreenFlash> { ToolScreen("Screen Flash", "screen_flash", navController, this@SharedTransitionLayout, this@composable) { ScreenFlashScreen() } }
-                    composable<PlumbBob> { ToolScreen("Plumb Bob", "plumb_bob", navController, this@SharedTransitionLayout, this@composable) { PlumbBobScreen() } }
-                    composable<WifiSignal> { ToolScreen("WiFi Signal", "wifi_signal", navController, this@SharedTransitionLayout, this@composable) { WifiSignalScreen() } }
+                    // Tool screens — when launched as the app root (default screen), back goes to Dashboard
+                    composable<Level> { ToolScreen("Bubble Level", "level", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is Level) { LevelScreen() } }
+                    composable<Compass> { ToolScreen("Compass", "compass", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is Compass) { CompassScreen() } }
+                    composable<Protractor> { ToolScreen("Protractor", "protractor", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is Protractor) { ProtractorScreen() } }
+                    composable<SoundMeter> { ToolScreen("Sound Meter", "sound_meter", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is SoundMeter) { SoundMeterScreen() } }
+                    composable<Ruler> { ToolScreen("Ruler", "ruler", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is Ruler) { RulerScreen() } }
+                    composable<UnitConverter> { ToolScreen("Unit Converter", "unit_converter", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is UnitConverter) { UnitConverterScreen() } }
+                    composable<PercentageCalculator> { ToolScreen("Percentage", "percentage", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is PercentageCalculator) { PercentageScreen() } }
+                    composable<TipCalculator> { ToolScreen("Tip Calculator", "tip_calculator", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is TipCalculator) { TipCalculatorScreen() } }
+                    composable<NumberBase> { ToolScreen("Number Base", "number_base", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is NumberBase) { NumberBaseScreen() } }
+                    composable<Flashlight> { ToolScreen("Flashlight", "flashlight", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is Flashlight) { FlashlightScreen() } }
+                    composable<QrScanner> { ToolScreen("QR & Barcode", "qr_scanner", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is QrScanner) { QrScannerScreen() } }
+                    composable<Counter> { ToolScreen("Counter", "counter", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is Counter) { CounterScreen() } }
+                    composable<StopwatchTimer> { ToolScreen("Stopwatch & Timer", "stopwatch_timer", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is StopwatchTimer) { StopwatchTimerScreen() } }
+                    composable<RandomGenerator> { ToolScreen("Random Generator", "random_generator", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is RandomGenerator) { RandomScreen() } }
+                    composable<ColorPicker> { ToolScreen("Color Picker", "color_picker", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is ColorPicker) { ColorPickerScreen() } }
+                    composable<Magnifier> { ToolScreen("Magnifier", "magnifier", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is Magnifier) { MagnifierScreen() } }
+                    composable<Mirror> { ToolScreen("Mirror", "mirror", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is Mirror) { MirrorScreen() } }
+                    composable<Vibrometer> { ToolScreen("Vibrometer", "vibrometer", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is Vibrometer) { VibrometerScreen() } }
+                    composable<LightMeter> { ToolScreen("Light Meter", "light_meter", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is LightMeter) { LightMeterScreen() } }
+                    composable<MetalDetector> { ToolScreen("Metal Detector", "metal_detector", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is MetalDetector) { MetalDetectorScreen() } }
+                    composable<Barometer> { ToolScreen("Barometer", "barometer", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is Barometer) { BarometerScreen() } }
+                    composable<Humidity> { ToolScreen("Humidity", "humidity", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is Humidity) { HumidityScreen() } }
+                    composable<Pedometer> { ToolScreen("Pedometer", "pedometer", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is Pedometer) { PedometerScreen() } }
+                    composable<Gyroscope> { ToolScreen("Gyroscope", "gyroscope", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is Gyroscope) { GyroscopeScreen() } }
+                    composable<HeartRate> { ToolScreen("Heart Rate", "heart_rate", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is HeartRate) { HeartRateScreen() } }
+                    composable<SpectrumAnalyzer> { ToolScreen("Spectrum Analyzer", "spectrum_analyzer", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is SpectrumAnalyzer) { SpectrumScreen() } }
+                    composable<Speedometer> { ToolScreen("Speedometer", "speedometer", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is Speedometer) { SpeedometerScreen() } }
+                    composable<Altitude> { ToolScreen("Altitude", "altitude", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is Altitude) { AltitudeScreen() } }
+                    composable<BreathingExercise> { ToolScreen("Breathing Exercise", "breathing_exercise", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is BreathingExercise) { BreathingExerciseScreen() } }
+                    composable<ScientificCalculator> { ToolScreen("Calculator", "scientific_calculator", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is ScientificCalculator) { CalculatorScreen() } }
+                    composable<MorseCode> { ToolScreen("Morse Code", "morse_code", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is MorseCode) { MorseCodeScreen() } }
+                    composable<DateCalculator> { ToolScreen("Date/Age Calculator", "date_calculator", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is DateCalculator) { DateCalculatorScreen() } }
+                    composable<BmiCalculator> { ToolScreen("BMI Calculator", "bmi_calculator", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is BmiCalculator) { BmiCalculatorScreen() } }
+                    composable<AspectRatio> { ToolScreen("Aspect Ratio", "aspect_ratio", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is AspectRatio) { AspectRatioScreen() } }
+                    composable<PasswordGenerator> { ToolScreen("Password Generator", "password_generator", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is PasswordGenerator) { PasswordGeneratorScreen() } }
+                    composable<WhiteNoise> { ToolScreen("Ambient Sounds", "white_noise", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is WhiteNoise) { WhiteNoiseScreen() } }
+                    composable<Metronome> { ToolScreen("Metronome", "metronome", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is Metronome) { MetronomeScreen() } }
+                    composable<PitchTuner> { ToolScreen("Pitch Tuner", "pitch_tuner", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is PitchTuner) { PitchTunerScreen() } }
+                    composable<ScreenFlash> { ToolScreen("Screen Flash", "screen_flash", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is ScreenFlash) { ScreenFlashScreen() } }
+                    composable<PlumbBob> { ToolScreen("Plumb Bob", "plumb_bob", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is PlumbBob) { PlumbBobScreen() } }
+                    composable<WifiSignal> { ToolScreen("WiFi Signal", "wifi_signal", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is WifiSignal) { WifiSignalScreen() } }
 
                     // Batch 2 Tools
-                    composable<EmiCalculator> { ToolScreen("Loan/EMI Calculator", "emi_calculator", navController, this@SharedTransitionLayout, this@composable) { EmiCalculatorScreen() } }
-                    composable<DeviceInfo> { ToolScreen("Device Info", "device_info", navController, this@SharedTransitionLayout, this@composable) { DeviceInfoScreen() } }
-                    composable<NetworkInfo> { ToolScreen("Network Info", "network_info", navController, this@SharedTransitionLayout, this@composable) { NetworkInfoScreen() } }
-                    composable<NfcToolkit> { ToolScreen("NFC Toolkit", "nfc_toolkit", navController, this@SharedTransitionLayout, this@composable) { NfcToolkitScreen() } }
-                    composable<ToneGenerator> { ToolScreen("Tone Generator", "tone_generator", navController, this@SharedTransitionLayout, this@composable) { ToneGeneratorScreen() } }
-                    composable<FormulaReference> { ToolScreen("Formulas", "formula_reference", navController, this@SharedTransitionLayout, this@composable) { FormulaScreen() } }
-                    composable<WifiQrShare> { ToolScreen("WiFi QR Share", "wifi_qr_share", navController, this@SharedTransitionLayout, this@composable) { WifiQrShareScreen() } }
-                    composable<PhotoCleanup> { ToolScreen("Photo Cleanup", "photo_cleanup", navController, this@SharedTransitionLayout, this@composable) { PhotoCleanupScreen() } }
-                    composable<WireGauge> { ToolScreen("Wire Gauge", "wire_gauge", navController, this@SharedTransitionLayout, this@composable) { WireGaugeScreen() } }
-                    composable<PaintCalculator> { ToolScreen("Paint Calculator", "paint_calculator", navController, this@SharedTransitionLayout, this@composable) { PaintCalculatorScreen() } }
-                    composable<ScrewBolt> { ToolScreen("Screw & Bolt", "screw_bolt", navController, this@SharedTransitionLayout, this@composable) { ScrewBoltScreen() } }
-                    composable<ScreenGrid> { ToolScreen("Screen Test Grid", "screen_grid", navController, this@SharedTransitionLayout, this@composable) { ScreenGridScreen() } }
-                    composable<TtsReader> { ToolScreen("TTS Reader", "tts_reader", navController, this@SharedTransitionLayout, this@composable) { TtsReaderScreen() } }
-                    composable<VibrationPatterns> { ToolScreen("Vibration Patterns", "vibration_patterns", navController, this@SharedTransitionLayout, this@composable) { VibrationPatternsScreen() } }
-                    composable<Ocr> { ToolScreen("Text Scanner", "ocr", navController, this@SharedTransitionLayout, this@composable) { OcrScreen() } }
-                    composable<UnitCircle> { ToolScreen("Unit Circle", "unit_circle", navController, this@SharedTransitionLayout, this@composable) { UnitCircleScreen() } }
+                    composable<EmiCalculator> { ToolScreen("Loan/EMI Calculator", "emi_calculator", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is EmiCalculator) { EmiCalculatorScreen() } }
+                    composable<DeviceInfo> { ToolScreen("Device Info", "device_info", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is DeviceInfo) { DeviceInfoScreen() } }
+                    composable<NetworkInfo> { ToolScreen("Network Info", "network_info", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is NetworkInfo) { NetworkInfoScreen() } }
+                    composable<NfcToolkit> { ToolScreen("NFC Toolkit", "nfc_toolkit", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is NfcToolkit) { NfcToolkitScreen() } }
+                    composable<ToneGenerator> { ToolScreen("Tone Generator", "tone_generator", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is ToneGenerator) { ToneGeneratorScreen() } }
+                    composable<FormulaReference> { ToolScreen("Formulas", "formula_reference", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is FormulaReference) { FormulaScreen() } }
+                    composable<WifiQrShare> { ToolScreen("WiFi QR Share", "wifi_qr_share", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is WifiQrShare) { WifiQrShareScreen() } }
+                    composable<PhotoCleanup> { ToolScreen("Photo Cleanup", "photo_cleanup", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is PhotoCleanup) { PhotoCleanupScreen() } }
+                    composable<WireGauge> { ToolScreen("Wire Gauge", "wire_gauge", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is WireGauge) { WireGaugeScreen() } }
+                    composable<PaintCalculator> { ToolScreen("Paint Calculator", "paint_calculator", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is PaintCalculator) { PaintCalculatorScreen() } }
+                    composable<ScrewBolt> { ToolScreen("Screw & Bolt", "screw_bolt", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is ScrewBolt) { ScrewBoltScreen() } }
+                    composable<ScreenGrid> { ToolScreen("Screen Test Grid", "screen_grid", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is ScreenGrid) { ScreenGridScreen() } }
+                    composable<TtsReader> { ToolScreen("TTS Reader", "tts_reader", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is TtsReader) { TtsReaderScreen() } }
+                    composable<VibrationPatterns> { ToolScreen("Vibration Patterns", "vibration_patterns", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is VibrationPatterns) { VibrationPatternsScreen() } }
+                    composable<Ocr> { ToolScreen("Text Scanner", "ocr", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is Ocr) { OcrScreen() } }
+                    composable<UnitCircle> { ToolScreen("Unit Circle", "unit_circle", navController, this@SharedTransitionLayout, this@composable, isDefaultRoot = isDefaultTool && startDest is UnitCircle) { UnitCircleScreen() } }
                 }
             }
         }
@@ -346,6 +358,7 @@ private fun ToolScreen(
     navController: NavController,
     sharedTransitionScope: SharedTransitionScope? = null,
     animatedVisibilityScope: AnimatedVisibilityScope? = null,
+    isDefaultRoot: Boolean = false,
     content: @Composable () -> Unit,
 ) {
     val context = androidx.compose.ui.platform.LocalContext.current
@@ -353,6 +366,18 @@ private fun ToolScreen(
     val favoriteIds by repository.favoriteToolIds.collectAsState(initial = emptySet())
     val isFavorite = toolId in favoriteIds
     val scope = androidx.compose.runtime.rememberCoroutineScope()
+
+    // When this tool is the root (default screen), back should go to Dashboard not exit
+    val onBack: () -> Unit = if (isDefaultRoot && !navController.previousBackStackEntry?.destination?.route.isNullOrEmpty() == false) {
+        {
+            navController.navigate(Dashboard) {
+                popUpTo(0) { inclusive = true }
+                launchSingleTop = true
+            }
+        }
+    } else {
+        { navController.popBackStack() }
+    }
 
     val helpText = remember(toolId) { allTools.find { it.id == toolId }?.description?.takeIf { it.isNotBlank() } }
 
@@ -372,7 +397,7 @@ private fun ToolScreen(
 
     ToolScaffold(
         title = title,
-        onBack = { navController.popBackStack() },
+        onBack = onBack,
         modifier = sharedModifier,
         helpText = helpText,
         actions = {

--- a/app/src/main/java/com/toolbox/ToolboxApp.kt
+++ b/app/src/main/java/com/toolbox/ToolboxApp.kt
@@ -1,5 +1,6 @@
 package com.toolbox
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionLayout
@@ -367,8 +368,17 @@ private fun ToolScreen(
     val isFavorite = toolId in favoriteIds
     val scope = androidx.compose.runtime.rememberCoroutineScope()
 
-    // When this tool is the root (default screen), back should go to Dashboard not exit
-    val onBack: () -> Unit = if (isDefaultRoot && !navController.previousBackStackEntry?.destination?.route.isNullOrEmpty() == false) {
+    // When this tool IS the default root and has no previous back stack entry (i.e. the user
+    // launched the app directly into this tool), intercept BOTH the system back gesture and the
+    // scaffold back button so they navigate to Dashboard instead of exiting the app.
+    val isAtRoot = isDefaultRoot && navController.previousBackStackEntry == null
+    BackHandler(enabled = isAtRoot) {
+        navController.navigate(Dashboard) {
+            popUpTo(0) { inclusive = true }
+            launchSingleTop = true
+        }
+    }
+    val onBack: () -> Unit = if (isAtRoot) {
         {
             navController.navigate(Dashboard) {
                 popUpTo(0) { inclusive = true }

--- a/app/src/main/java/com/toolbox/conversion/calculator/CalculatorScreen.kt
+++ b/app/src/main/java/com/toolbox/conversion/calculator/CalculatorScreen.kt
@@ -11,12 +11,16 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardReturn
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
@@ -39,6 +43,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 @Composable
 fun CalculatorScreen(
     viewModel: CalculatorViewModel = viewModel(),
+    onUseResult: ((String) -> Unit)? = null,
 ) {
     val state by viewModel.state.collectAsState()
     val haptic = LocalHapticFeedback.current
@@ -84,21 +89,39 @@ fun CalculatorScreen(
 
         Spacer(modifier = Modifier.height(8.dp))
 
-        // DEG / RAD toggle
-        SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-            SegmentedButton(
-                selected = state.useDegrees,
-                onClick = { if (!state.useDegrees) viewModel.toggleAngleMode() },
-                shape = SegmentedButtonDefaults.itemShape(0, 2),
-            ) {
-                Text("DEG")
+        // DEG / RAD toggle + optional "Use Result" button
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            SingleChoiceSegmentedButtonRow(modifier = Modifier.weight(1f)) {
+                SegmentedButton(
+                    selected = state.useDegrees,
+                    onClick = { if (!state.useDegrees) viewModel.toggleAngleMode() },
+                    shape = SegmentedButtonDefaults.itemShape(0, 2),
+                ) {
+                    Text("DEG")
+                }
+                SegmentedButton(
+                    selected = !state.useDegrees,
+                    onClick = { if (state.useDegrees) viewModel.toggleAngleMode() },
+                    shape = SegmentedButtonDefaults.itemShape(1, 2),
+                ) {
+                    Text("RAD")
+                }
             }
-            SegmentedButton(
-                selected = !state.useDegrees,
-                onClick = { if (state.useDegrees) viewModel.toggleAngleMode() },
-                shape = SegmentedButtonDefaults.itemShape(1, 2),
-            ) {
-                Text("RAD")
+            if (onUseResult != null && state.result.isNotBlank() && state.result != "Error") {
+                OutlinedButton(
+                    onClick = { onUseResult(state.result) },
+                ) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.KeyboardReturn,
+                        contentDescription = null,
+                        modifier = Modifier.padding(end = 4.dp),
+                    )
+                    Text("Use", fontWeight = FontWeight.SemiBold)
+                }
             }
         }
 

--- a/app/src/main/java/com/toolbox/conversion/unitconverter/UnitConverterScreen.kt
+++ b/app/src/main/java/com/toolbox/conversion/unitconverter/UnitConverterScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.toolbox.conversion.calculator.CalculatorScreen
+import com.toolbox.conversion.calculator.CalculatorViewModel
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -66,6 +67,9 @@ fun UnitConverterScreen(
     var showCalculatorSheet by remember { mutableStateOf(false) }
     val calculatorSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val scope = rememberCoroutineScope()
+    // Hoist the ViewModel outside the `if` so the calculator state (expression, result)
+    // survives sheet dismiss and is restored when the sheet is reopened.
+    val calculatorViewModel: CalculatorViewModel = viewModel()
 
     Box(modifier = Modifier.fillMaxSize()) {
         Column(
@@ -204,6 +208,7 @@ fun UnitConverterScreen(
             sheetState = calculatorSheetState,
         ) {
             CalculatorScreen(
+                viewModel = calculatorViewModel,
                 onUseResult = { result ->
                     viewModel.onFromValueChanged(result)
                     scope.launch {

--- a/app/src/main/java/com/toolbox/conversion/unitconverter/UnitConverterScreen.kt
+++ b/app/src/main/java/com/toolbox/conversion/unitconverter/UnitConverterScreen.kt
@@ -2,6 +2,7 @@ package com.toolbox.conversion.unitconverter
 
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -16,6 +17,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Calculate
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.SwapVert
@@ -30,15 +32,19 @@ import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -46,6 +52,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.toolbox.conversion.calculator.CalculatorScreen
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -54,112 +62,156 @@ fun UnitConverterScreen(
 ) {
     val state by viewModel.state.collectAsState()
     val units = unitsByCategory[state.category] ?: emptyList()
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(16.dp),
-    ) {
-        // Category chips with icons
-        Row(
+
+    var showCalculatorSheet by remember { mutableStateOf(false) }
+    val calculatorSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val scope = rememberCoroutineScope()
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
             modifier = Modifier
-                .fillMaxWidth()
-                .horizontalScroll(rememberScrollState()),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
         ) {
-            UnitCategory.entries.forEach { category ->
-                FilterChip(
-                    selected = state.category == category,
-                    onClick = { viewModel.onCategoryChanged(category) },
-                    leadingIcon = {
-                        Icon(
-                            imageVector = category.icon,
-                            contentDescription = null,
-                            modifier = Modifier.size(18.dp),
-                        )
-                    },
-                    label = { Text(category.label) },
-                )
-            }
-        }
-
-        Spacer(modifier = Modifier.height(20.dp))
-
-        // From card
-        ConversionCard(
-            label = "From",
-            selectedUnit = state.fromUnit,
-            units = units,
-            onUnitSelected = viewModel::onFromUnitChanged,
-            value = state.fromValue,
-            onValueChanged = viewModel::onFromValueChanged,
-            placeholder = "Enter value",
-        )
-
-        // Swap + favorite row
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 4.dp),
-            horizontalArrangement = Arrangement.Center,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            IconButton(onClick = viewModel::swapUnits) {
-                Icon(
-                    Icons.Default.SwapVert,
-                    contentDescription = "Swap units",
-                    modifier = Modifier.size(28.dp),
-                    tint = MaterialTheme.colorScheme.primary,
-                )
-            }
-            Spacer(modifier = Modifier.width(8.dp))
-            IconButton(onClick = viewModel::toggleCurrentFavorite) {
-                Icon(
-                    imageVector = if (state.isCurrentFavorite) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
-                    contentDescription = if (state.isCurrentFavorite) "Remove from favorites" else "Add to favorites",
-                    modifier = Modifier.size(24.dp),
-                    tint = if (state.isCurrentFavorite) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-        }
-
-        // To card
-        ConversionCard(
-            label = "To",
-            selectedUnit = state.toUnit,
-            units = units,
-            onUnitSelected = viewModel::onToUnitChanged,
-            value = state.toValue,
-            onValueChanged = viewModel::onToValueChanged,
-            placeholder = "Result",
-        )
-
-        // Favorite conversion pairs (global, across all categories)
-        if (state.favoriteConversions.isNotEmpty()) {
-            Spacer(modifier = Modifier.height(20.dp))
-
-            Text(
-                text = "Favorites",
-                style = MaterialTheme.typography.labelLarge,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
+            // Category chips with icons
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
                     .horizontalScroll(rememberScrollState()),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                state.favoriteConversions.forEach { key ->
-                    val label = key.substringAfter(":")
-                    SuggestionChip(
-                        onClick = { viewModel.applyFavorite(key) },
-                        label = { Text(label, style = MaterialTheme.typography.labelSmall) },
+                UnitCategory.entries.forEach { category ->
+                    FilterChip(
+                        selected = state.category == category,
+                        onClick = { viewModel.onCategoryChanged(category) },
+                        leadingIcon = {
+                            Icon(
+                                imageVector = category.icon,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp),
+                            )
+                        },
+                        label = { Text(category.label) },
                     )
                 }
             }
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            // From card
+            ConversionCard(
+                label = "From",
+                selectedUnit = state.fromUnit,
+                units = units,
+                onUnitSelected = viewModel::onFromUnitChanged,
+                value = state.fromValue,
+                onValueChanged = viewModel::onFromValueChanged,
+                placeholder = "Enter value",
+            )
+
+            // Swap + favorite row
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 4.dp),
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                IconButton(onClick = viewModel::swapUnits) {
+                    Icon(
+                        Icons.Default.SwapVert,
+                        contentDescription = "Swap units",
+                        modifier = Modifier.size(28.dp),
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                }
+                Spacer(modifier = Modifier.width(8.dp))
+                IconButton(onClick = viewModel::toggleCurrentFavorite) {
+                    Icon(
+                        imageVector = if (state.isCurrentFavorite) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
+                        contentDescription = if (state.isCurrentFavorite) "Remove from favorites" else "Add to favorites",
+                        modifier = Modifier.size(24.dp),
+                        tint = if (state.isCurrentFavorite) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            // To card
+            ConversionCard(
+                label = "To",
+                selectedUnit = state.toUnit,
+                units = units,
+                onUnitSelected = viewModel::onToUnitChanged,
+                value = state.toValue,
+                onValueChanged = viewModel::onToValueChanged,
+                placeholder = "Result",
+            )
+
+            // Favorite conversion pairs (global, across all categories)
+            if (state.favoriteConversions.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(20.dp))
+
+                Text(
+                    text = "Favorites",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .horizontalScroll(rememberScrollState()),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    state.favoriteConversions.forEach { key ->
+                        val label = key.substringAfter(":")
+                        SuggestionChip(
+                            onClick = { viewModel.applyFavorite(key) },
+                            label = { Text(label, style = MaterialTheme.typography.labelSmall) },
+                        )
+                    }
+                }
+            }
+
+            // Extra bottom padding so the FAB doesn't overlap last content
+            Spacer(modifier = Modifier.height(72.dp))
+        }
+
+        // Floating calculator button pinned to bottom-right
+        SmallFloatingActionButton(
+            onClick = { showCalculatorSheet = true },
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(16.dp),
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        ) {
+            Icon(
+                imageVector = Icons.Default.Calculate,
+                contentDescription = "Open Calculator",
+                modifier = Modifier.size(20.dp),
+            )
+        }
+    }
+
+    // Calculator bottom sheet
+    if (showCalculatorSheet) {
+        ModalBottomSheet(
+            onDismissRequest = { showCalculatorSheet = false },
+            sheetState = calculatorSheetState,
+        ) {
+            CalculatorScreen(
+                onUseResult = { result ->
+                    viewModel.onFromValueChanged(result)
+                    scope.launch {
+                        calculatorSheetState.hide()
+                        showCalculatorSheet = false
+                    }
+                },
+            )
         }
     }
 }

--- a/app/src/main/java/com/toolbox/core/persistence/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/toolbox/core/persistence/UserPreferencesRepository.kt
@@ -21,6 +21,7 @@ class UserPreferencesRepository(private val context: Context) {
         val FAVORITE_TOOLS = stringSetPreferencesKey("favorite_tools")
         val PINNED_TOOLS = stringSetPreferencesKey("pinned_tools")
         val FAVORITE_CONVERSIONS = stringSetPreferencesKey("favorite_conversions")
+        val DEFAULT_SCREEN = stringPreferencesKey("default_screen")
         const val MAX_PINNED = 3
     }
 
@@ -32,6 +33,16 @@ class UserPreferencesRepository(private val context: Context) {
     suspend fun setThemeMode(mode: ThemeMode) {
         context.dataStore.edit { prefs ->
             prefs[THEME_MODE] = mode.name
+        }
+    }
+
+    val defaultScreenId: Flow<String> = context.dataStore.data.map { prefs ->
+        prefs[DEFAULT_SCREEN] ?: "dashboard"
+    }
+
+    suspend fun setDefaultScreen(screenId: String) {
+        context.dataStore.edit { prefs ->
+            prefs[DEFAULT_SCREEN] = screenId
         }
     }
 

--- a/app/src/main/java/com/toolbox/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/toolbox/settings/SettingsScreen.kt
@@ -26,7 +26,10 @@ import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.CloudOff
 import androidx.compose.material.icons.filled.Construction
 import androidx.compose.material.icons.filled.DarkMode
+import androidx.compose.material.icons.filled.Dashboard
 import androidx.compose.material.icons.filled.DeleteSweep
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.LightMode
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.ShieldMoon
@@ -38,10 +41,14 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -54,14 +61,21 @@ import androidx.compose.ui.unit.sp
 import com.toolbox.core.export.MeasurementLog
 import com.toolbox.core.persistence.ThemeMode
 import com.toolbox.core.persistence.UserPreferencesRepository
+import com.toolbox.dashboard.allTools
 import kotlinx.coroutines.launch
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
+import androidx.compose.ui.graphics.Color
 
 @Composable
 fun SettingsScreen() {
     val context = LocalContext.current
     val repository = UserPreferencesRepository(context)
     val themeMode by repository.themeMode.collectAsState(initial = ThemeMode.System)
+    val defaultScreenId by repository.defaultScreenId.collectAsState(initial = "dashboard")
     val scope = rememberCoroutineScope()
+    var showDefaultScreenDialog by remember { mutableStateOf(false) }
 
     Column(
         modifier = Modifier
@@ -69,6 +83,65 @@ fun SettingsScreen() {
             .verticalScroll(rememberScrollState())
             .padding(24.dp),
     ) {
+        // Startup section
+        SectionHeader("Startup")
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Card(
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+            ),
+            shape = RoundedCornerShape(16.dp),
+        ) {
+            // Determine display name for current default
+            val defaultScreenLabel = when (defaultScreenId) {
+                "dashboard" -> "Dashboard"
+                "favorites" -> "Favorites"
+                else -> allTools.find { it.id == defaultScreenId }?.name ?: "Dashboard"
+            }
+            val defaultScreenIcon: ImageVector = when (defaultScreenId) {
+                "dashboard" -> Icons.Default.Dashboard
+                "favorites" -> Icons.Default.Favorite
+                else -> allTools.find { it.id == defaultScreenId }?.icon ?: Icons.Default.Home
+            }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { showDefaultScreenDialog = true }
+                    .padding(horizontal = 20.dp, vertical = 14.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    defaultScreenIcon,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(24.dp),
+                )
+                Spacer(modifier = Modifier.width(16.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "Default Screen",
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    Text(
+                        text = defaultScreenLabel,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Icon(
+                    Icons.Default.Dashboard,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
         // Appearance section
         SectionHeader("Appearance")
 
@@ -273,6 +346,81 @@ fun SettingsScreen() {
         )
 
         Spacer(modifier = Modifier.height(16.dp))
+    }
+
+    // Default Screen Selection Dialog
+    if (showDefaultScreenDialog) {
+        data class ScreenOption(val id: String, val name: String, val icon: androidx.compose.ui.graphics.vector.ImageVector)
+
+        val fixedOptions = listOf(
+            ScreenOption("dashboard", "Dashboard", Icons.Default.Dashboard),
+            ScreenOption("favorites", "Favorites", Icons.Default.Favorite),
+        )
+        val toolOptions = allTools
+            .sortedBy { it.name }
+            .map { ScreenOption(it.id, it.name, it.icon) }
+        val allOptions = fixedOptions + toolOptions
+
+        AlertDialog(
+            onDismissRequest = { showDefaultScreenDialog = false },
+            title = {
+                Text(
+                    text = "Default Screen",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            },
+            text = {
+                LazyColumn {
+                    items(allOptions) { option ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    scope.launch { repository.setDefaultScreen(option.id) }
+                                    showDefaultScreenDialog = false
+                                }
+                                .padding(vertical = 10.dp, horizontal = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Icon(
+                                option.icon,
+                                contentDescription = null,
+                                modifier = Modifier.size(22.dp),
+                                tint = if (defaultScreenId == option.id)
+                                    MaterialTheme.colorScheme.primary
+                                else
+                                    MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            Spacer(modifier = Modifier.width(14.dp))
+                            Text(
+                                text = option.name,
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = if (defaultScreenId == option.id) FontWeight.SemiBold else FontWeight.Normal,
+                                color = if (defaultScreenId == option.id)
+                                    MaterialTheme.colorScheme.primary
+                                else
+                                    MaterialTheme.colorScheme.onSurface,
+                                modifier = Modifier.weight(1f),
+                            )
+                            if (defaultScreenId == option.id) {
+                                Icon(
+                                    Icons.Default.CheckCircle,
+                                    contentDescription = "Selected",
+                                    modifier = Modifier.size(18.dp),
+                                    tint = MaterialTheme.colorScheme.primary,
+                                )
+                            }
+                        }
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { showDefaultScreenDialog = false }) {
+                    Text("Done")
+                }
+            },
+        )
     }
 }
 

--- a/app/src/main/java/com/toolbox/widgets/CounterWidget.kt
+++ b/app/src/main/java/com/toolbox/widgets/CounterWidget.kt
@@ -1,5 +1,8 @@
 package com.toolbox.widgets
 
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.Color
+
 import android.content.Context
 import android.content.Intent
 import androidx.datastore.preferences.core.stringPreferencesKey
@@ -33,7 +36,6 @@ import androidx.glance.text.TextAlign
 import androidx.glance.text.TextStyle
 import androidx.compose.ui.unit.sp
 import androidx.glance.unit.ColorProvider
-import android.graphics.Color
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.preferencesDataStore
@@ -58,9 +60,9 @@ class CounterWidget : GlanceAppWidget() {
                 Column(
                     modifier = GlanceModifier
                         .fillMaxSize()
-                        .background(Color.WHITE)
-                        .cornerRadius(16)
-                        .padding(12)
+                        .background(ColorProvider(Color(0xFFFFFFFF)))
+                        .cornerRadius(16.dp)
+                        .padding(12.dp)
                         .clickable(actionStartActivity<MainActivity>(
                             actionParametersOf(ActionParameters.Key<String>("tool_id") to "counter")
                         )),
@@ -71,21 +73,21 @@ class CounterWidget : GlanceAppWidget() {
                         text = counter.name,
                         style = TextStyle(
                             fontSize = 12.sp,
-                            color = ColorProvider(Color.GRAY),
+                            color = ColorProvider(Color(0xFF888888)),
                         ),
                         maxLines = 1,
                     )
-                    Spacer(modifier = GlanceModifier.height(4))
+                    Spacer(modifier = GlanceModifier.height(4.dp))
                     Text(
                         text = "${counter.value}",
                         style = TextStyle(
                             fontSize = 36.sp,
                             fontWeight = FontWeight.Bold,
-                            color = ColorProvider(Color.BLACK),
+                            color = ColorProvider(Color(0xFF000000)),
                             textAlign = TextAlign.Center,
                         ),
                     )
-                    Spacer(modifier = GlanceModifier.height(8))
+                    Spacer(modifier = GlanceModifier.height(8.dp))
                     Row(
                         modifier = GlanceModifier.fillMaxWidth(),
                         horizontalAlignment = Alignment.CenterHorizontally,
@@ -93,28 +95,28 @@ class CounterWidget : GlanceAppWidget() {
                         Text(
                             text = "  −  ",
                             modifier = GlanceModifier
-                                .background(Color.parseColor("#F0F0F0"))
-                                .cornerRadius(8)
-                                .padding(horizontal = 16, vertical = 6)
+                                .background(ColorProvider(Color(0xFFF0F0F0)))
+                                .cornerRadius(8.dp)
+                                .padding(horizontal = 16.dp, vertical = 6.dp)
                                 .clickable(actionRunCallback<DecrementAction>()),
                             style = TextStyle(
                                 fontSize = 18.sp,
                                 fontWeight = FontWeight.Bold,
-                                color = ColorProvider(Color.parseColor("#EF5350")),
+                                color = ColorProvider(Color(0xFFEF5350)),
                             ),
                         )
-                        Spacer(modifier = GlanceModifier.width(12))
+                        Spacer(modifier = GlanceModifier.width(12.dp))
                         Text(
                             text = "  +  ",
                             modifier = GlanceModifier
-                                .background(Color.parseColor("#F0F0F0"))
-                                .cornerRadius(8)
-                                .padding(horizontal = 16, vertical = 6)
+                                .background(ColorProvider(Color(0xFFF0F0F0)))
+                                .cornerRadius(8.dp)
+                                .padding(horizontal = 16.dp, vertical = 6.dp)
                                 .clickable(actionRunCallback<IncrementAction>()),
                             style = TextStyle(
                                 fontSize = 18.sp,
                                 fontWeight = FontWeight.Bold,
-                                color = ColorProvider(Color.parseColor("#66BB6A")),
+                                color = ColorProvider(Color(0xFF66BB6A)),
                             ),
                         )
                     }

--- a/app/src/main/java/com/toolbox/widgets/DateCountdownWidget.kt
+++ b/app/src/main/java/com/toolbox/widgets/DateCountdownWidget.kt
@@ -2,7 +2,6 @@ package com.toolbox.widgets
 
 import android.app.Activity
 import android.content.Context
-import android.graphics.Color
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -29,6 +28,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.sp
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.longPreferencesKey
@@ -100,8 +100,8 @@ class DateCountdownWidget : GlanceAppWidget() {
                     GlanceColumn(
                         modifier = GlanceModifier
                             .glanceFillMaxSize()
-                            .background(Color.WHITE)
-                            .cornerRadius(16)
+                            .background(ColorProvider(Color(0xFFFFFFFF)))
+                            .cornerRadius(16.dp)
                             .glancePadding(12)
                             .clickable(actionStartActivity<CountdownConfigActivity>()),
                         verticalAlignment = GlanceAlignment.CenterVertically,
@@ -116,7 +116,7 @@ class DateCountdownWidget : GlanceAppWidget() {
                             text = "Tap to set\ncountdown",
                             style = TextStyle(
                                 fontSize = 12.sp,
-                                color = ColorProvider(Color.GRAY),
+                                color = ColorProvider(Color(0xFF888888)),
                                 textAlign = TextAlign.Center,
                             ),
                         )
@@ -124,23 +124,23 @@ class DateCountdownWidget : GlanceAppWidget() {
                 } else {
                     val days = state.daysRemaining()
                     val bgColor = when {
-                        days < 0 -> Color.parseColor("#FFEBEE") // past
-                        days == 0L -> Color.parseColor("#FFF3E0") // today
-                        days <= 7 -> Color.parseColor("#FFF8E1") // soon
-                        else -> Color.WHITE
+                        days < 0 -> Color(0xFFFFEBEE) // past
+                        days == 0L -> Color(0xFFFFF3E0) // today
+                        days <= 7 -> Color(0xFFFFF8E1) // soon
+                        else -> Color(0xFFFFFFFF)
                     }
                     val daysColor = when {
-                        days < 0 -> Color.parseColor("#C62828")
-                        days == 0L -> Color.parseColor("#E65100")
-                        days <= 7 -> Color.parseColor("#F57F17")
-                        else -> Color.parseColor("#1565C0")
+                        days < 0 -> Color(0xFFC62828)
+                        days == 0L -> Color(0xFFE65100)
+                        days <= 7 -> Color(0xFFF57F17)
+                        else -> Color(0xFF1565C0)
                     }
 
                     GlanceColumn(
                         modifier = GlanceModifier
                             .glanceFillMaxSize()
-                            .background(bgColor)
-                            .cornerRadius(16)
+                            .background(ColorProvider(bgColor))
+                            .cornerRadius(16.dp)
                             .glancePadding(12)
                             .clickable(actionStartActivity<MainActivity>(
                                 actionParametersOf(ActionParameters.Key<String>("tool_id") to "date_calculator")
@@ -153,7 +153,7 @@ class DateCountdownWidget : GlanceAppWidget() {
                                 text = state.label,
                                 style = TextStyle(
                                     fontSize = 12.sp,
-                                    color = ColorProvider(Color.GRAY),
+                                    color = ColorProvider(Color(0xFF888888)),
                                 ),
                                 maxLines = 1,
                             )
@@ -177,7 +177,7 @@ class DateCountdownWidget : GlanceAppWidget() {
                                 text = if (days < 0) "days ago" else if (days == 1L) "day left" else "days left",
                                 style = TextStyle(
                                     fontSize = 12.sp,
-                                    color = ColorProvider(Color.GRAY),
+                                    color = ColorProvider(Color(0xFF888888)),
                                 ),
                             )
                         }
@@ -186,7 +186,7 @@ class DateCountdownWidget : GlanceAppWidget() {
                             text = state.targetDateFormatted(),
                             style = TextStyle(
                                 fontSize = 10.sp,
-                                color = ColorProvider(Color.LTGRAY),
+                                color = ColorProvider(Color(0xFFCCCCCC)),
                             ),
                         )
                     }

--- a/app/src/main/java/com/toolbox/widgets/FavoritesSliderWidget.kt
+++ b/app/src/main/java/com/toolbox/widgets/FavoritesSliderWidget.kt
@@ -1,7 +1,9 @@
 package com.toolbox.widgets
 
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.Color
+
 import android.content.Context
-import android.graphics.Color
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.sp
 import androidx.datastore.preferences.core.edit
@@ -121,9 +123,9 @@ private fun EmptyFavoritesContent() {
     Column(
         modifier = GlanceModifier
             .fillMaxSize()
-            .background(Color.WHITE)
-            .cornerRadius(16)
-            .padding(16)
+            .background(ColorProvider(Color(0xFFFFFFFF)))
+            .cornerRadius(16.dp)
+            .padding(16.dp)
             .clickable(actionStartActivity<MainActivity>()),
         verticalAlignment = Alignment.CenterVertically,
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -132,22 +134,22 @@ private fun EmptyFavoritesContent() {
             text = "\u2B50",
             style = TextStyle(fontSize = 28.sp),
         )
-        Spacer(modifier = GlanceModifier.height(8))
+        Spacer(modifier = GlanceModifier.height(8.dp))
         Text(
             text = "No favorites yet",
             style = TextStyle(
                 fontSize = 14.sp,
                 fontWeight = FontWeight.Medium,
-                color = ColorProvider(Color.GRAY),
+                color = ColorProvider(Color(0xFF888888)),
                 textAlign = TextAlign.Center,
             ),
         )
-        Spacer(modifier = GlanceModifier.height(4))
+        Spacer(modifier = GlanceModifier.height(4.dp))
         Text(
             text = "Long-press any tool to favorite it",
             style = TextStyle(
                 fontSize = 11.sp,
-                color = ColorProvider(Color.LTGRAY),
+                color = ColorProvider(Color(0xFFCCCCCC)),
                 textAlign = TextAlign.Center,
             ),
         )
@@ -166,9 +168,9 @@ private fun SliderContent(favorites: List<String>, pageIndex: Int) {
     Column(
         modifier = GlanceModifier
             .fillMaxSize()
-            .background(Color.WHITE)
-            .cornerRadius(16)
-            .padding(8),
+            .background(ColorProvider(Color(0xFFFFFFFF)))
+            .cornerRadius(16.dp)
+            .padding(8.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
@@ -183,7 +185,7 @@ private fun SliderContent(favorites: List<String>, pageIndex: Int) {
                 style = TextStyle(
                     fontSize = 12.sp,
                     fontWeight = FontWeight.Bold,
-                    color = ColorProvider(Color.parseColor("#A67C00")),
+                    color = ColorProvider(Color(0xFFA67C00)),
                 ),
             )
             if (totalPages > 1) {
@@ -191,12 +193,12 @@ private fun SliderContent(favorites: List<String>, pageIndex: Int) {
                     text = "  ${safePageIndex + 1}/$totalPages",
                     style = TextStyle(
                         fontSize = 10.sp,
-                        color = ColorProvider(Color.GRAY),
+                        color = ColorProvider(Color(0xFF888888)),
                     ),
                 )
             }
         }
-        Spacer(modifier = GlanceModifier.height(6))
+        Spacer(modifier = GlanceModifier.height(6.dp))
 
         // Slider row: [<] [tool] [tool] [tool] [tool] [>]
         Row(
@@ -208,8 +210,8 @@ private fun SliderContent(favorites: List<String>, pageIndex: Int) {
             Text(
                 text = " ◀ ",
                 modifier = GlanceModifier
-                    .cornerRadius(8)
-                    .padding(vertical = 8, horizontal = 4)
+                    .cornerRadius(8.dp)
+                    .padding(vertical = 8.dp, horizontal = 4.dp)
                     .clickable(
                         if (hasPrev) actionRunCallback<FavSliderPrevAction>()
                         else actionRunCallback<FavSliderNoOpAction>()
@@ -217,7 +219,7 @@ private fun SliderContent(favorites: List<String>, pageIndex: Int) {
                 style = TextStyle(
                     fontSize = 14.sp,
                     color = ColorProvider(
-                        if (hasPrev) Color.parseColor("#333333") else Color.parseColor("#DDDDDD")
+                        if (hasPrev) Color(0xFF333333) else Color(0xFFDDDDDD)
                     ),
                 ),
             )
@@ -225,22 +227,22 @@ private fun SliderContent(favorites: List<String>, pageIndex: Int) {
             // Tool items
             for (toolId in pageItems) {
                 val (emoji, name) = toolEmojiMap[toolId] ?: ("\uD83D\uDD27" to toolId)
-                Spacer(modifier = GlanceModifier.width(4))
+                Spacer(modifier = GlanceModifier.width(4.dp))
                 FavoriteToolItem(emoji, name, toolId)
             }
             // Fill remaining slots with spacers if less than ITEMS_PER_PAGE
             repeat(ITEMS_PER_PAGE - pageItems.size) {
-                Spacer(modifier = GlanceModifier.width(4))
-                Spacer(modifier = GlanceModifier.width(52))
+                Spacer(modifier = GlanceModifier.width(4.dp))
+                Spacer(modifier = GlanceModifier.width(52.dp))
             }
 
-            Spacer(modifier = GlanceModifier.width(4))
+            Spacer(modifier = GlanceModifier.width(4.dp))
             // Right arrow
             Text(
                 text = " ▶ ",
                 modifier = GlanceModifier
-                    .cornerRadius(8)
-                    .padding(vertical = 8, horizontal = 4)
+                    .cornerRadius(8.dp)
+                    .padding(vertical = 8.dp, horizontal = 4.dp)
                     .clickable(
                         if (hasNext) actionRunCallback<FavSliderNextAction>()
                         else actionRunCallback<FavSliderNoOpAction>()
@@ -248,7 +250,7 @@ private fun SliderContent(favorites: List<String>, pageIndex: Int) {
                 style = TextStyle(
                     fontSize = 14.sp,
                     color = ColorProvider(
-                        if (hasNext) Color.parseColor("#333333") else Color.parseColor("#DDDDDD")
+                        if (hasNext) Color(0xFF333333) else Color(0xFFDDDDDD)
                     ),
                 ),
             )
@@ -260,9 +262,9 @@ private fun SliderContent(favorites: List<String>, pageIndex: Int) {
 private fun FavoriteToolItem(emoji: String, name: String, toolId: String) {
     Column(
         modifier = GlanceModifier
-            .background(Color.parseColor("#F5F5F5"))
-            .cornerRadius(12)
-            .padding(6)
+            .background(ColorProvider(Color(0xFFF5F5F5)))
+            .cornerRadius(12.dp)
+            .padding(6.dp)
             .clickable(
                 actionStartActivity<MainActivity>(
                     actionParametersOf(ActionParameters.Key<String>("tool_id") to toolId)
@@ -274,12 +276,12 @@ private fun FavoriteToolItem(emoji: String, name: String, toolId: String) {
             text = emoji,
             style = TextStyle(fontSize = 22.sp),
         )
-        Spacer(modifier = GlanceModifier.height(2))
+        Spacer(modifier = GlanceModifier.height(2.dp))
         Text(
             text = name,
             style = TextStyle(
                 fontSize = 9.sp,
-                color = ColorProvider(Color.parseColor("#555555")),
+                color = ColorProvider(Color(0xFF555555)),
                 textAlign = TextAlign.Center,
             ),
             maxLines = 1,

--- a/app/src/main/java/com/toolbox/widgets/FlashlightWidget.kt
+++ b/app/src/main/java/com/toolbox/widgets/FlashlightWidget.kt
@@ -1,7 +1,9 @@
 package com.toolbox.widgets
 
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.Color
+
 import android.content.Context
-import android.graphics.Color
 import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraManager
 import androidx.compose.ui.unit.sp
@@ -48,9 +50,9 @@ class FlashlightWidget : GlanceAppWidget() {
                 Column(
                     modifier = GlanceModifier
                         .fillMaxSize()
-                        .background(if (isOn) Color.parseColor("#FFF9C4") else Color.WHITE)
-                        .cornerRadius(16)
-                        .padding(8)
+                        .background(ColorProvider(if (isOn) Color(0xFFFFF9C4) else Color(0xFFFFFFFF)))
+                        .cornerRadius(16.dp)
+                        .padding(8.dp)
                         .clickable(actionRunCallback<ToggleFlashlightAction>()),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalAlignment = Alignment.CenterHorizontally,
@@ -59,14 +61,14 @@ class FlashlightWidget : GlanceAppWidget() {
                         text = if (isOn) "\uD83D\uDD26" else "\uD83D\uDD26",
                         style = TextStyle(fontSize = 32.sp),
                     )
-                    Spacer(modifier = GlanceModifier.height(4))
+                    Spacer(modifier = GlanceModifier.height(4.dp))
                     Text(
                         text = if (isOn) "ON" else "OFF",
                         style = TextStyle(
                             fontSize = 14.sp,
                             fontWeight = FontWeight.Bold,
                             color = ColorProvider(
-                                if (isOn) Color.parseColor("#F57F17") else Color.GRAY
+                                if (isOn) Color(0xFFF57F17) else Color(0xFF888888)
                             ),
                             textAlign = TextAlign.Center,
                         ),

--- a/app/src/main/java/com/toolbox/widgets/PedometerWidget.kt
+++ b/app/src/main/java/com/toolbox/widgets/PedometerWidget.kt
@@ -1,7 +1,9 @@
 package com.toolbox.widgets
 
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.Color
+
 import android.content.Context
-import android.graphics.Color
 import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
@@ -103,9 +105,9 @@ class PedometerWidget : GlanceAppWidget() {
                 Column(
                     modifier = GlanceModifier
                         .fillMaxSize()
-                        .background(Color.WHITE)
-                        .cornerRadius(16)
-                        .padding(12)
+                        .background(ColorProvider(Color(0xFFFFFFFF)))
+                        .cornerRadius(16.dp)
+                        .padding(12.dp)
                         .clickable(actionStartActivity<MainActivity>(
                             actionParametersOf(
                                 ActionParameters.Key<String>("tool_id") to "pedometer"
@@ -119,11 +121,11 @@ class PedometerWidget : GlanceAppWidget() {
                         text = "Pedometer",
                         style = TextStyle(
                             fontSize = 12.sp,
-                            color = ColorProvider(Color.GRAY),
+                            color = ColorProvider(Color(0xFF888888)),
                         ),
                         maxLines = 1,
                     )
-                    Spacer(modifier = GlanceModifier.height(4))
+                    Spacer(modifier = GlanceModifier.height(4.dp))
 
                     // Step count
                     Text(
@@ -131,7 +133,7 @@ class PedometerWidget : GlanceAppWidget() {
                         style = TextStyle(
                             fontSize = 32.sp,
                             fontWeight = FontWeight.Bold,
-                            color = ColorProvider(Color.BLACK),
+                            color = ColorProvider(Color(0xFF000000)),
                             textAlign = TextAlign.Center,
                         ),
                     )
@@ -139,24 +141,24 @@ class PedometerWidget : GlanceAppWidget() {
                         text = "steps today",
                         style = TextStyle(
                             fontSize = 11.sp,
-                            color = ColorProvider(Color.parseColor("#2E7D32")),
+                            color = ColorProvider(Color(0xFF2E7D32)),
                         ),
                     )
 
                     // Session info (when active)
                     if (state.sessionActive) {
-                        Spacer(modifier = GlanceModifier.height(4))
+                        Spacer(modifier = GlanceModifier.height(4.dp))
                         Text(
                             text = "${numberFormat.format(state.sessionSteps)} session · ${formatDuration(state.sessionDurationMs)}",
                             style = TextStyle(
                                 fontSize = 11.sp,
-                                color = ColorProvider(Color.parseColor("#1565C0")),
+                                color = ColorProvider(Color(0xFF1565C0)),
                             ),
                             maxLines = 1,
                         )
                     }
 
-                    Spacer(modifier = GlanceModifier.height(8))
+                    Spacer(modifier = GlanceModifier.height(8.dp))
 
                     // Buttons row
                     Row(
@@ -167,34 +169,34 @@ class PedometerWidget : GlanceAppWidget() {
                         Text(
                             text = " ↻ ",
                             modifier = GlanceModifier
-                                .background(Color.parseColor("#F0F0F0"))
-                                .cornerRadius(8)
-                                .padding(horizontal = 12, vertical = 6)
+                                .background(ColorProvider(Color(0xFFF0F0F0)))
+                                .cornerRadius(8.dp)
+                                .padding(horizontal = 12.dp, vertical = 6.dp)
                                 .clickable(actionRunCallback<PedometerRefreshAction>()),
                             style = TextStyle(
                                 fontSize = 16.sp,
                                 fontWeight = FontWeight.Bold,
-                                color = ColorProvider(Color.GRAY),
+                                color = ColorProvider(Color(0xFF888888)),
                             ),
                         )
-                        Spacer(modifier = GlanceModifier.width(8))
+                        Spacer(modifier = GlanceModifier.width(8.dp))
                         // Session start/stop button
                         Text(
                             text = if (state.sessionActive) " ⏹ " else " ▶ ",
                             modifier = GlanceModifier
-                                .background(
-                                    if (state.sessionActive) Color.parseColor("#FFEBEE")
-                                    else Color.parseColor("#E8F5E9")
-                                )
-                                .cornerRadius(8)
-                                .padding(horizontal = 12, vertical = 6)
+                                .background(ColorProvider(
+                                    if (state.sessionActive) Color(0xFFFFEBEE)
+                                    else Color(0xFFE8F5E9)
+                                ))
+                                .cornerRadius(8.dp)
+                                .padding(horizontal = 12.dp, vertical = 6.dp)
                                 .clickable(actionRunCallback<PedometerSessionAction>()),
                             style = TextStyle(
                                 fontSize = 16.sp,
                                 fontWeight = FontWeight.Bold,
                                 color = ColorProvider(
-                                    if (state.sessionActive) Color.parseColor("#C62828")
-                                    else Color.parseColor("#2E7D32")
+                                    if (state.sessionActive) Color(0xFFC62828)
+                                    else Color(0xFF2E7D32)
                                 ),
                             ),
                         )

--- a/app/src/main/java/com/toolbox/widgets/QuickLaunchWidget.kt
+++ b/app/src/main/java/com/toolbox/widgets/QuickLaunchWidget.kt
@@ -1,7 +1,9 @@
 package com.toolbox.widgets
 
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.Color
+
 import android.content.Context
-import android.graphics.Color
 import androidx.compose.runtime.Composable
 import androidx.glance.GlanceId
 import androidx.glance.GlanceModifier
@@ -40,9 +42,9 @@ class QuickLaunchWidget : GlanceAppWidget() {
                 Column(
                     modifier = GlanceModifier
                         .fillMaxSize()
-                        .background(Color.WHITE)
-                        .cornerRadius(16)
-                        .padding(8),
+                        .background(ColorProvider(Color(0xFFFFFFFF)))
+                        .cornerRadius(16.dp)
+                        .padding(8.dp),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
@@ -51,34 +53,34 @@ class QuickLaunchWidget : GlanceAppWidget() {
                         style = TextStyle(
                             fontSize = 14.sp,
                             fontWeight = FontWeight.Bold,
-                            color = ColorProvider(Color.parseColor("#1B5E20")),
+                            color = ColorProvider(Color(0xFF1B5E20)),
                             textAlign = TextAlign.Center,
                         ),
                     )
-                    Spacer(modifier = GlanceModifier.height(8))
+                    Spacer(modifier = GlanceModifier.height(8.dp))
                     Row(
                         modifier = GlanceModifier.fillMaxWidth(),
                         horizontalAlignment = Alignment.CenterHorizontally,
                     ) {
                         ToolButton("\uD83D\uDD26", "flashlight")
-                        Spacer(modifier = GlanceModifier.width(6))
+                        Spacer(modifier = GlanceModifier.width(6.dp))
                         ToolButton("\uD83D\uDCD0", "level")
-                        Spacer(modifier = GlanceModifier.width(6))
+                        Spacer(modifier = GlanceModifier.width(6.dp))
                         ToolButton("\uD83E\uDDED", "compass")
-                        Spacer(modifier = GlanceModifier.width(6))
+                        Spacer(modifier = GlanceModifier.width(6.dp))
                         ToolButton("\u23F1\uFE0F", "stopwatch_timer")
                     }
-                    Spacer(modifier = GlanceModifier.height(6))
+                    Spacer(modifier = GlanceModifier.height(6.dp))
                     Row(
                         modifier = GlanceModifier.fillMaxWidth(),
                         horizontalAlignment = Alignment.CenterHorizontally,
                     ) {
                         ToolButton("\uD83D\uDCCF", "ruler")
-                        Spacer(modifier = GlanceModifier.width(6))
+                        Spacer(modifier = GlanceModifier.width(6.dp))
                         ToolButton("\uD83D\uDD0A", "sound_meter")
-                        Spacer(modifier = GlanceModifier.width(6))
+                        Spacer(modifier = GlanceModifier.width(6.dp))
                         ToolButton("\uD83C\uDFB2", "random")
-                        Spacer(modifier = GlanceModifier.width(6))
+                        Spacer(modifier = GlanceModifier.width(6.dp))
                         ToolButton("\uD83D\uDCF7", "qr_scanner")
                     }
                 }
@@ -92,9 +94,9 @@ private fun ToolButton(emoji: String, toolId: String) {
     Text(
         text = emoji,
         modifier = GlanceModifier
-            .background(Color.parseColor("#F5F5F5"))
-            .cornerRadius(12)
-            .padding(10)
+            .background(ColorProvider(Color(0xFFF5F5F5)))
+            .cornerRadius(12.dp)
+            .padding(10.dp)
             .clickable(
                 actionStartActivity<MainActivity>(
                     actionParametersOf(ActionParameters.Key<String>("tool_id") to toolId)

--- a/app/src/main/java/com/toolbox/widgets/StopwatchWidget.kt
+++ b/app/src/main/java/com/toolbox/widgets/StopwatchWidget.kt
@@ -1,7 +1,9 @@
 package com.toolbox.widgets
 
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.Color
+
 import android.content.Context
-import android.graphics.Color
 import androidx.compose.ui.unit.sp
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
@@ -70,9 +72,9 @@ class StopwatchWidget : GlanceAppWidget() {
                 Column(
                     modifier = GlanceModifier
                         .fillMaxSize()
-                        .background(Color.WHITE)
-                        .cornerRadius(16)
-                        .padding(12)
+                        .background(ColorProvider(Color(0xFFFFFFFF)))
+                        .cornerRadius(16.dp)
+                        .padding(12.dp)
                         .clickable(actionStartActivity<MainActivity>(
                             actionParametersOf(ActionParameters.Key<String>("tool_id") to "stopwatch_timer")
                         )),
@@ -83,23 +85,23 @@ class StopwatchWidget : GlanceAppWidget() {
                         text = "Stopwatch",
                         style = TextStyle(
                             fontSize = 12.sp,
-                            color = ColorProvider(Color.GRAY),
+                            color = ColorProvider(Color(0xFF888888)),
                         ),
                         maxLines = 1,
                     )
-                    Spacer(modifier = GlanceModifier.height(4))
+                    Spacer(modifier = GlanceModifier.height(4.dp))
                     Text(
                         text = timeText,
                         style = TextStyle(
                             fontSize = 28.sp,
                             fontWeight = FontWeight.Bold,
                             color = ColorProvider(
-                                if (state.isRunning) Color.parseColor("#2E7D32") else Color.BLACK
+                                if (state.isRunning) Color(0xFF2E7D32) else Color(0xFF000000)
                             ),
                             textAlign = TextAlign.Center,
                         ),
                     )
-                    Spacer(modifier = GlanceModifier.height(8))
+                    Spacer(modifier = GlanceModifier.height(8.dp))
                     Row(
                         modifier = GlanceModifier.fillMaxWidth(),
                         horizontalAlignment = Alignment.CenterHorizontally,
@@ -108,35 +110,35 @@ class StopwatchWidget : GlanceAppWidget() {
                         Text(
                             text = if (state.isRunning) " ⏸ " else " ▶ ",
                             modifier = GlanceModifier
-                                .background(
-                                    if (state.isRunning) Color.parseColor("#FFF3E0")
-                                    else Color.parseColor("#E8F5E9")
-                                )
-                                .cornerRadius(8)
-                                .padding(horizontal = 14, vertical = 6)
+                                .background(ColorProvider(
+                                    if (state.isRunning) Color(0xFFFFF3E0)
+                                    else Color(0xFFE8F5E9)
+                                ))
+                                .cornerRadius(8.dp)
+                                .padding(horizontal = 14.dp, vertical = 6.dp)
                                 .clickable(actionRunCallback<StopwatchStartPauseAction>()),
                             style = TextStyle(
                                 fontSize = 16.sp,
                                 fontWeight = FontWeight.Bold,
                                 color = ColorProvider(
-                                    if (state.isRunning) Color.parseColor("#E65100")
-                                    else Color.parseColor("#2E7D32")
+                                    if (state.isRunning) Color(0xFFE65100)
+                                    else Color(0xFF2E7D32)
                                 ),
                             ),
                         )
-                        Spacer(modifier = GlanceModifier.width(10))
+                        Spacer(modifier = GlanceModifier.width(10.dp))
                         // Reset button
                         Text(
                             text = " ↺ ",
                             modifier = GlanceModifier
-                                .background(Color.parseColor("#F0F0F0"))
-                                .cornerRadius(8)
-                                .padding(horizontal = 14, vertical = 6)
+                                .background(ColorProvider(Color(0xFFF0F0F0)))
+                                .cornerRadius(8.dp)
+                                .padding(horizontal = 14.dp, vertical = 6.dp)
                                 .clickable(actionRunCallback<StopwatchResetAction>()),
                             style = TextStyle(
                                 fontSize = 16.sp,
                                 fontWeight = FontWeight.Bold,
-                                color = ColorProvider(Color.GRAY),
+                                color = ColorProvider(Color(0xFF888888)),
                             ),
                         )
                     }

--- a/app/src/main/java/com/toolbox/widgets/UnitConverterWidget.kt
+++ b/app/src/main/java/com/toolbox/widgets/UnitConverterWidget.kt
@@ -1,7 +1,9 @@
 package com.toolbox.widgets
 
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.Color
+
 import android.content.Context
-import android.graphics.Color
 import androidx.compose.ui.unit.sp
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
@@ -96,9 +98,9 @@ class UnitConverterWidget : GlanceAppWidget() {
                 Column(
                     modifier = GlanceModifier
                         .fillMaxSize()
-                        .background(Color.WHITE)
-                        .cornerRadius(16)
-                        .padding(12)
+                        .background(ColorProvider(Color(0xFFFFFFFF)))
+                        .cornerRadius(16.dp)
+                        .padding(12.dp)
                         .clickable(actionStartActivity<MainActivity>(
                             actionParametersOf(ActionParameters.Key<String>("tool_id") to "unit_converter")
                         )),
@@ -116,27 +118,27 @@ class UnitConverterWidget : GlanceAppWidget() {
                             style = TextStyle(
                                 fontSize = 24.sp,
                                 fontWeight = FontWeight.Bold,
-                                color = ColorProvider(Color.BLACK),
+                                color = ColorProvider(Color(0xFF000000)),
                             ),
                         )
-                        Spacer(modifier = GlanceModifier.width(4))
+                        Spacer(modifier = GlanceModifier.width(4.dp))
                         Text(
                             text = pair.fromSymbol,
                             style = TextStyle(
                                 fontSize = 16.sp,
-                                color = ColorProvider(Color.GRAY),
+                                color = ColorProvider(Color(0xFF888888)),
                             ),
                         )
                     }
-                    Spacer(modifier = GlanceModifier.height(2))
+                    Spacer(modifier = GlanceModifier.height(2.dp))
                     Text(
                         text = "=",
                         style = TextStyle(
                             fontSize = 14.sp,
-                            color = ColorProvider(Color.GRAY),
+                            color = ColorProvider(Color(0xFF888888)),
                         ),
                     )
-                    Spacer(modifier = GlanceModifier.height(2))
+                    Spacer(modifier = GlanceModifier.height(2.dp))
                     // Result row
                     Row(
                         modifier = GlanceModifier.fillMaxWidth(),
@@ -148,19 +150,19 @@ class UnitConverterWidget : GlanceAppWidget() {
                             style = TextStyle(
                                 fontSize = 24.sp,
                                 fontWeight = FontWeight.Bold,
-                                color = ColorProvider(Color.parseColor("#1565C0")),
+                                color = ColorProvider(Color(0xFF1565C0)),
                             ),
                         )
-                        Spacer(modifier = GlanceModifier.width(4))
+                        Spacer(modifier = GlanceModifier.width(4.dp))
                         Text(
                             text = pair.toSymbol,
                             style = TextStyle(
                                 fontSize = 16.sp,
-                                color = ColorProvider(Color.GRAY),
+                                color = ColorProvider(Color(0xFF888888)),
                             ),
                         )
                     }
-                    Spacer(modifier = GlanceModifier.height(8))
+                    Spacer(modifier = GlanceModifier.height(8.dp))
                     // Controls: cycle pair, increment value
                     Row(
                         modifier = GlanceModifier.fillMaxWidth(),
@@ -169,42 +171,42 @@ class UnitConverterWidget : GlanceAppWidget() {
                         Text(
                             text = " ⇄ ",
                             modifier = GlanceModifier
-                                .background(Color.parseColor("#E3F2FD"))
-                                .cornerRadius(8)
-                                .padding(horizontal = 12, vertical = 4)
+                                .background(ColorProvider(Color(0xFFE3F2FD)))
+                                .cornerRadius(8.dp)
+                                .padding(horizontal = 12.dp, vertical = 4.dp)
                                 .clickable(actionRunCallback<CyclePairAction>()),
                             style = TextStyle(
                                 fontSize = 14.sp,
                                 fontWeight = FontWeight.Bold,
-                                color = ColorProvider(Color.parseColor("#1565C0")),
+                                color = ColorProvider(Color(0xFF1565C0)),
                             ),
                         )
-                        Spacer(modifier = GlanceModifier.width(6))
+                        Spacer(modifier = GlanceModifier.width(6.dp))
                         Text(
                             text = " − ",
                             modifier = GlanceModifier
-                                .background(Color.parseColor("#F0F0F0"))
-                                .cornerRadius(8)
-                                .padding(horizontal = 12, vertical = 4)
+                                .background(ColorProvider(Color(0xFFF0F0F0)))
+                                .cornerRadius(8.dp)
+                                .padding(horizontal = 12.dp, vertical = 4.dp)
                                 .clickable(actionRunCallback<DecrementValueAction>()),
                             style = TextStyle(
                                 fontSize = 14.sp,
                                 fontWeight = FontWeight.Bold,
-                                color = ColorProvider(Color.parseColor("#EF5350")),
+                                color = ColorProvider(Color(0xFFEF5350)),
                             ),
                         )
-                        Spacer(modifier = GlanceModifier.width(6))
+                        Spacer(modifier = GlanceModifier.width(6.dp))
                         Text(
                             text = " + ",
                             modifier = GlanceModifier
-                                .background(Color.parseColor("#F0F0F0"))
-                                .cornerRadius(8)
-                                .padding(horizontal = 12, vertical = 4)
+                                .background(ColorProvider(Color(0xFFF0F0F0)))
+                                .cornerRadius(8.dp)
+                                .padding(horizontal = 12.dp, vertical = 4.dp)
                                 .clickable(actionRunCallback<IncrementValueAction>()),
                             style = TextStyle(
                                 fontSize = 14.sp,
                                 fontWeight = FontWeight.Bold,
-                                color = ColorProvider(Color.parseColor("#66BB6A")),
+                                color = ColorProvider(Color(0xFF66BB6A)),
                             ),
                         )
                     }


### PR DESCRIPTION
- Add DEFAULT_SCREEN preference to UserPreferencesRepository (DataStore)
- MainActivity waits for preference load before rendering to avoid screen flash
- ToolboxApp dynamically sets NavHost startDestination based on saved preference
  - Supports Dashboard, Favorites, or any individual tool as the default screen
  - When a tool is the root, back button navigates to Dashboard instead of exiting
- SettingsScreen: new Startup section with Default Screen picker dialog
  - Lists Dashboard, Favorites, and all 60+ tools sorted alphabetically
  - Active selection highlighted with primary color and checkmark
- UnitConverterScreen: floating calculator FAB (bottom-right)
  - Tapping opens CalculatorScreen in a ModalBottomSheet
  - 'Use' button appears when a valid result is computed
  - Tapping 'Use' inserts the result into the From field and closes the sheet
- CalculatorScreen: optional onUseResult callback for embedding in other screens
- versionCode 5 / versionName 1.3.1